### PR TITLE
Add address search in Received headers

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -75,6 +75,10 @@ defaultRoomConfig:
   # If true, the To header will be searched for valid targets (rooms).
   useToAsTarget: true
 
+  # If true, the Received header will be searched for valid targets (rooms).
+  # Useful for redirected emails (as used by sieve or mailman).
+  useEnvelopeToAsTarget: false
+
   # If true, the bot won't post an HTML message to the Matrix room, instead posting a plain
   # text message. It is recommended to use $text_body in your formatting to avoid HTML tags
   # being posted in the rough to the room.

--- a/src/EmailProcessor.ts
+++ b/src/EmailProcessor.ts
@@ -9,7 +9,7 @@ import { MessageType } from "./MessageType";
 interface IEmailTarget {
     address: string;
     name: string;
-    source: "to" | "cc" | "bcc";
+    source: "to" | "cc" | "bcc" | "envelope";
 }
 
 export class EmailProcessor {
@@ -36,6 +36,15 @@ export class EmailProcessor {
         for (const email of (message.to || [])) targets.push({address: email.address, name: email.name, source: 'to'});
         for (const email of (message.cc || [])) targets.push({address: email.address, name: email.name, source: 'cc'});
         for (const email of (message.bcc || [])) targets.push({address: email.address, name: email.name, source: 'bcc'});
+        for (const header of (message.headerLines || [])) {
+            if (header.key == 'received') {
+                const regex = /for <(.*)>/;
+                const email = header.line.match(regex);
+                if (email) {
+                    targets.push({address: email[1], name: '', source: 'envelope'});
+                }
+            }
+        }
 
         const primaryFrom = message.from[0];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface IRoomConfig {
     useCcAsTarget: boolean;
     useBccAsTarget: boolean;
     useToAsTarget: boolean;
+    useEnvelopeToAsTarget: boolean;
     plaintextOnly: boolean;
     attachments: {
         post: boolean;

--- a/src/configUtils.ts
+++ b/src/configUtils.ts
@@ -13,7 +13,7 @@ export function getRoomConfig(roomId: string): IAnnotatedRoomConfig {
     return Object.assign({}, {roomId}, defaults, overrides) as IAnnotatedRoomConfig;
 }
 
-export function getRoomConfigsForTarget(emailAddress: string, source: "cc" | "bcc" | "to"): IAnnotatedRoomConfig[] {
+export function getRoomConfigsForTarget(emailAddress: string, source: "cc" | "bcc" | "to" | "envelope"): IAnnotatedRoomConfig[] {
     const configs: IAnnotatedRoomConfig[] = [];
     const customMapping = config.customMailTargets[emailAddress];
     if (!customMapping) {
@@ -41,6 +41,7 @@ export function getRoomConfigsForTarget(emailAddress: string, source: "cc" | "bc
         if (source === "cc" && !roomConfig.useCcAsTarget) continue;
         if (source === "bcc" && !roomConfig.useBccAsTarget) continue;
         if (source === "to" && !roomConfig.useToAsTarget) continue;
+        if (source === "envelope" && !roomConfig.useEnvelopeToAsTarget) continue;
         freshConfigs.push(roomConfig);
     }
 


### PR DESCRIPTION
This should help to integrate the bot in certain existing mailserver environments.

We use an existing postfix, dovecot and sieve setup to "redirect" incoming external mails to `@bot.server` addresses. We also use mailman for mailing lists. Both cases do not "rewrite" the `To` header so it could be picked up by the bot. A separate postfix (configured as in #72) on `bot.server` handles mail for the bot, which also accepts internal mail directed to `@bot.server`.
 
This enables searching for addresses in `Received` headers, which is the only source of the room addresses when using redirects.